### PR TITLE
Fix pagetemplate import for Plone 4.3 compatibility

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 1.4.8 (Unreleased)
 ------------------
 
+* Fix pagetemplate import for Plone 4.3 compatibility.
+  [jone]
+
 * Add Chinese translation.
   [jianaijun]
 

--- a/collective/z3cform/wizard/wizard.py
+++ b/collective/z3cform/wizard/wizard.py
@@ -25,13 +25,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import zope.component
 from zope.interface import implements
-from zope.app.pagetemplate import viewpagetemplatefile
 from z3c.form import button, field, form, interfaces, group
 from Products.statusmessages.interfaces import IStatusMessage
 
 from collective.z3cform.wizard import utils
 from collective.z3cform.wizard.interfaces import IWizard, IStep
 from collective.z3cform.wizard.i18n import MessageFactory as _
+
+
+try:
+    from zope.browserpage import viewpagetemplatefile
+except ImportError:
+    # Plone < 4.1
+    from zope.app.pagetemplate import viewpagetemplatefile
+
 
 WIZARD_SESSION_KEY = 'collective.z3cform.wizard'
 
@@ -356,4 +363,4 @@ class Wizard(utils.OverridableTemplate, form.Form):
 
     @property
     def absolute_url(self):
-        return self.context.absolute_url() + '/' + (self.__name__ or '') 
+        return self.context.absolute_url() + '/' + (self.__name__ or '')


### PR DESCRIPTION
`zope.app.pagetemplate.viewpagetemplatefile.ViewPageTemplateFile` was moved to `zope.browserpage.viewpagetemplatefile.ViewPageTemplateFile`
- `zope.app.pagetemplate` is no longer included in Plone >= 4.3
- `zope.browserpage.viewpagetemplatefile` works from Plone >= 4.1

btw. is `Products.Five.browser.pagetemplatefile.ViewPageTemplateFile` preferred?
